### PR TITLE
chore: update NewPipeExtractor

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.github.teamnewpipe:NewPipeExtractor:3af73262cc60cf555fd5f1d691f6c58e2db38ef5'
+        implementation 'com.github.teamnewpipe:NewPipeExtractor:0695a0982bf31e5f554419f5531b3af505992b03'
         implementation "com.squareup.okhttp3:okhttp:4.12.0"
         implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -45,3 +45,8 @@
 -dontwarn jdk.dynalink.linker.support.CompositeTypeBasedGuardingDynamicLinker
 -dontwarn jdk.dynalink.linker.support.Guards
 -dontwarn jdk.dynalink.support.ChainedCallSite
+# Rules for jsoup
+# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
+# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
+# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
+-dontwarn com.google.re2j.**


### PR DESCRIPTION
Update `com.github.teamnewpipe:NewPipeExtractor` to v0.25.0 (commit `0695a0982bf31e5f554419f5531b3af505992b03`), fixes #2.